### PR TITLE
corrected affiliation; editing index for markdown errors

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ Currently we are upgrading (under process) the package to be implementable on bi
 
 In this section, we present a mathematical representation of the spherical harmonics analysis. According to potential theory, the gravitational field of a body fulfils the Laplace equation $\nabla^2\phi = 0$. Laplace's equation in spherical coordinates can be written as follows: 
 
-$$
+```
 \begin{equation}
 \frac{1}{r^2}\frac{\partial}{\partial r}\bigg( r^2\frac{\partial \phi}{\partial r}\bigg)  
 +
@@ -44,22 +44,24 @@ $$
 \frac{1}{r^2\sin^2\vartheta}\frac{\partial^2 \phi}{\partial \lambda^2}
  = 0 ,
 \end{equation}\\
-$$
+```
+
 
 where 
-$\phi$ is the potential, 
+$`\phi`$ is the potential, 
 $r$ is the radius, 
-$\vartheta$ is the co-latitude and 
-$\lambda$ is the longitude. 
+$`\vartheta`$ is the co-latitude and 
+$`\lambda`$ is the longitude. 
 
-We perform a separation of variables and insert $\phi(r,\vartheta,\lambda) =f(r)g(\vartheta)h(\lambda)$ into the Laplace equation to get three independent equations:
+We perform a separation of variables and insert $`\phi(r,\vartheta,\lambda) =f(r)g(\vartheta)h(\lambda)`$ into the Laplace equation to get three independent equations:
 
-$$
+
 \begin{equation}
 r^2\frac{d^2f}{dr^2}+2r\frac{df}{dr} - n(n+1)f = 0,
 \end{equation}
-$$
-$$
+
+
+
 \begin{equation}
 \frac{d^2g}{d\vartheta^2}
 +
@@ -67,34 +69,37 @@ $$
 +
 \bigg(  n(n+1) - \frac{m^2}{\sin^2\vartheta}   \bigg) g = 0 ,
 \end{equation}
-$$
-$$
+
+
+
 \begin{equation}
 \frac{d^2h}{d\lambda^2} + m^2h = 0,
 \end{equation}
-$$
+
 
 where $m$ and $n$ are the degree and order respectively. Solving $(2), (3)$ and $(4)$, we obtain: 
 
-$$
+
 \begin{equation}
 f(r) \in \{r^n, r^{-(n+1)}\},
 \end{equation}
-$$
-$$
+
+
+
 \begin{equation}
 g(\vartheta) \in \{P_{n,m}(\cos \vartheta), Q_{n,m}(\cos \vartheta)\} ,
 \end{equation}
-$$
-$$
+
+
+
 \begin{equation}
 h(\lambda) \in \{\cos m\lambda, \sin m\lambda\}.
 \end{equation}\\
-$$
+
 
 Thus, the Laplace equation's solution takes the following form: 
 
-$$
+
 \begin{equation}
 \phi(r, \vartheta, \lambda) = \sum_{n=0}^{\infty} \sum_{m=0}^{n} 
 \alpha_{n,m}
@@ -114,7 +119,7 @@ r^{(n+1)}\\
 \end{Bmatrix}
 .
 \end{equation}
-$$
+
 
 Solutions for $f(r)$ and $h(\lambda)$ are fairly straightforward. Eq - (3) for $g(\vartheta)$ is in the form of a Legendre differential equation and its solutions are $P_{n,m}(\cos \vartheta)$ and $Q_{n,m}(\cos \vartheta)$, the associated Legendre functions of the first and second kind. We now apply two constraints to the solution:
 
@@ -123,23 +128,23 @@ Solutions for $f(r)$ and $h(\lambda)$ are fairly straightforward. Eq - (3) for $
 
 which leads us to eliminate $Q_{n,m}(\cos \vartheta)$ and $r^n$.The $4\pi$ normalization of the Associated Legendre functions [8] is utilized in our package and is given by: 
 
-$$
+
 \begin{equation}
 \bar{P}_{n,m}(\cos\vartheta) = P_{n,m}(\cos\vartheta)\sqrt{(2-\delta_{m0})(2n+1)\frac{(n-m)!}{(n+m)!}},
 \end{equation}
-$$
+
 where $\delta_{m0}$ is the Kronecker delta function,
-$$
+
 \begin{equation}
 P_{n,m}(t) = (1-t^2)^{\frac{m}{2}}\frac{d^mP_n(t)}{dt^m},
 \end{equation}
-$$
+
 and 
-$$
+
 \begin{equation}
 nP_n(t)=-(n-1)P_{n-2}(t) + (2n-1)tP_{n-1}(t).
 \end{equation}
-$$
+
 
 Spherical harmonics are the angular portion of a set of solutions to Laplace's equation. They take into account $\vartheta$ and $\lambda$. They are functions modelled on the surface of a sphere, denoted by $Y_{n,m}(\vartheta,\lambda)$. They are of three kinds: 
 
@@ -151,20 +156,20 @@ Quantities like the gravitational potential, height of water column, gravity ano
 
 The gravitational potential anomaly $V$ is given by:
 
-$$
+
 \begin{equation}
     V(r, \vartheta, \lambda) = 
     \frac{GM}{r} \sum_{n=0} ^{N_{max}} \sum_{m=0} ^{n} 
     \left(\frac{R}{r}\right) ^{n+1}
     \bar{P}_{n,m}(\cos \vartheta)\[C_{n,m}\cos m\lambda+S_{n,m}\sin m\lambda\].
 \end{equation}
-$$
+
 
 Here, $R$ refers to the radius of the Earth,
 $\bar{P}_ {n,m}$ refers to the Associated Legendre functions with $4\pi$ normalization,
 $C_{lm}$ and  $S_{lm}$ refer to the spherical harmonic coefficients. Similarly, another functional, the change in surface mass density, is represented by:
 
-$$
+
 \begin{equation}
     \Delta\sigma(\vartheta, \lambda) = 
     \frac{a\rho_{ave}}{3} 
@@ -174,7 +179,7 @@ $$
     \frac{2n+1}{1+k_l}
     \[C_{n,m}\cos m\lambda + S_{n,m}\sin m\lambda\],
 \end{equation}
-$$
+
 
 where
 $\rho_{ave}$ refers to the average density of the Earth in $g/cm^3$ and

--- a/paper_joss.md
+++ b/paper_joss.md
@@ -23,7 +23,7 @@ authors:
   - name: Bramha Dutt Vishwakarma
     orcid: 0000-0003-4787-8470
     corresponding: true # (This is how to denote the corresponding author)
-    affiliation: "1,3" # (Multiple affiliations must be quoted)
+    affiliation: "1,4" # (Multiple affiliations must be quoted)
 affiliations:
  - name: Interdisciplinary Centre for Water Research, Indian Institute of Science, India
    index: 1


### PR DESCRIPTION
Hi @mn5hk , I have corrected the affiliation related mistake. I saw that there was similar math-markdown error in the `docs/index.md` file. 

![Screenshot from 2023-04-15 23-13-16](https://user-images.githubusercontent.com/97011961/232245145-5e7306e2-7192-43f0-aed4-e52328a0a5d2.png)

I am trying some edits for the math-markdown error on the GitHub pages site. 